### PR TITLE
Throw an error instead of log

### DIFF
--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -134,7 +134,8 @@ function contrib(config, commands, options){
 
   Command.execute(command, function(err, result){
     if (err) {
-      return log.error(err);
+      log.error(err);
+      throw err;
     }
 
     log.writeln(result);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,17 +15,27 @@ var Errors = module.exports = exports = {};
 
 var util = require('util');
 
-Errors.Config = function(message) {
-  Error.call(this);
-  this.message = message;
-};
+function createError(name, defaultMsg) {
+  var newErr = function CustomError(message, custom) {
+    Error.captureStackTrace(this, this.constructor);
+    this.message = message || defaultMsg;
 
-util.inherits(Errors.Config, Error);
+    custom = custom || {};
+    for (var key in custom) {
+      if (custom.hasOwnProperty(key)) {
+        this[key] = custom[key];
+      }
+    }
+  };
 
+  util.inherits(newErr, Error);
 
-Errors.User = function(message) {
-  Error.call(this);
-  this.message = message;
-};
+  newErr.prototype.name = name;
+  newErr.prototype.constructor = newErr;
 
-util.inherits(Errors.User, Error);
+  return newErr;
+}
+
+Errors.Config = createError('ConfigError');
+Errors.User = createError('UserError');
+Errors.Exec = createError('ExecError', 'Exec failed');

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -18,6 +18,7 @@ var handlebars = require('handlebars');
 var log = require('./log');
 var Command = require('./command');
 var _ = require('lodash');
+var Errors = require('./errors');
 
 /**
  * Perforn an exec step
@@ -116,7 +117,8 @@ Exec.do = function(step, callback){
 
         cp.on('close', function (code) {
           if (code > 0) {
-            callback(step.fail || 'exec failed');
+            var error = new Errors.Exec(step.fail, { code: result.code });
+            callback(error);
           } else {
             callback(null, result.trim());
           }
@@ -127,7 +129,8 @@ Exec.do = function(step, callback){
       result = shell.exec(cmd);
 
       if (result.code > 0) {
-        return callback(step.fail || 'exec failed');
+        var error = new Errors.Exec(step.fail, { code: result.code });
+        return callback(error);
       }
 
       callback(null, result.output.trim());


### PR DESCRIPTION
This will make contrib exit with a non-zero exit code so things like build pipelines won't foolishly think things have succeeded. Also introduced a new method for generating custom errors.