### PR TITLE
update node-proxy version - will be able to install on node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "handlebars": "~2.0.0-alpha.2",
     "lodash": "~2.4.1",
     "minimist": "0.0.8",
-    "node-proxy": "~0.8.0",
+    "node-proxy": "~0.9.0",
     "open": "0.0.5",
     "optimist": "~0.6.0",
     "prompt": "~0.2.13",


### PR DESCRIPTION
was able to install contrib on node 0.12.x after this change